### PR TITLE
how to hook into require('some-file.json') ?

### DIFF
--- a/test/extensions.js
+++ b/test/extensions.js
@@ -1,6 +1,7 @@
 /* (c) 2016 Ari Porad (@ariporad) <http://ariporad.com>. License: ariporad.mit-license.org */
 import test from 'ava';
 import rewire from 'rewire';
+import path from 'path';
 import { assertModule } from './helpers/utils';
 
 const call = (f) => f();
@@ -15,6 +16,24 @@ test('exts', (t) => {
   assertModule(t, 'extensions-main.js', 'a! @@a');
 
   reverts.forEach(call);
+});
+
+test('addHook works with .json files', (t) => {
+  const expected = [
+    'fixture/json.js',
+    'fixture/json.json'
+  ].map(filename => path.join(__dirname, filename));
+
+  const actual = [];
+  t.context.addHook((code, file) => {
+    actual.push(file);
+    return code;
+  }, {
+    exts: ['.js', '.json']
+  });
+
+  assertModule(t, 'json.js', 'json.json from json.js');
+  t.deepEqual(actual, expected);
 });
 
 // a: @@a @@d => a! @@b d! e!

--- a/test/fixture/json.js
+++ b/test/fixture/json.js
@@ -1,0 +1,1 @@
+module.exports = require("./json.json") + " from json.js";

--- a/test/fixture/json.json
+++ b/test/fixture/json.json
@@ -1,0 +1,1 @@
+"json.json"


### PR DESCRIPTION
I've made this PR to demonstrate a use case that, as far as I understand what `pirates` is intended for, should work: **hooking into `require()` calls to `.json` files**.

```shell
node -v # v13.2.0
npm -v # 6.13.2

npm ls --depth 0
# /Users/j/playground/pirates
# ├── @babel/cli@7.7.5
# ├── @babel/core@7.7.5
# ├── @babel/preset-env@7.7.6
# ├── ava@1.4.1
# ├── babel-core@7.0.0-bridge.0
# ├── babel-eslint@10.0.3
# ├── babel-plugin-istanbul@5.2.0
# ├── cross-env@5.2.1
# ├── cz-conventional-changelog@2.1.0
# ├── decache@4.5.1
# ├── eslint@5.16.0
# ├── eslint-config-prettier@4.3.0
# ├── eslint-plugin-import@2.19.1
# ├── eslint-plugin-prettier@3.1.1
# ├── mock-require@3.0.3
# ├── node-modules-regexp@1.0.0
# ├── nyc@13.3.0
# ├── prettier@1.19.1
# ├── rewire@4.0.1
# ├── rimraf@2.7.1
# └── semantic-release@15.13.31
#
# npm ERR! peer dep missing: ajv@^5.0.0, required by ajv-keywords@2.1.1
# npm ERR! peer dep missing: ajv@^5.0.0, required by ajv-keywords@2.1.1

ava
#  ✔ GoodNonPirateHooks › non-pirates hooks
#  ✔ basics › basics
#  ✔ basics › matchers
#  ✔ basics › matcher is called only once per file
#  ✔ extensions › exts
#  ✖ extensions › addHook works with .json files
#  ✔ extensions › chain
#
#  1 test failed
#
#  extensions › addHook works with .json files
#
#  /Users/j/playground/pirates/test/extensions.js:36
#
#   35:   assertModule(t, 'json.js', 'json.json from json.js');
#   36:   t.deepEqual(actual, expected);
#   37: });
#
#  Difference:
#
#    [
#      '/Users/j/playground/pirates/test/fixture/json.js',
#  +   '/Users/j/playground/pirates/test/fixture/json.json',
#    ]
```

[package-lock.json.zip](https://github.com/ariporad/pirates/files/3940711/package-lock.json.zip)

**If this is intended to work, I can submit a fix.**