### PR TITLE
fix: Correctly revert to undefined if no previous loader exists

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -105,7 +105,7 @@ export function addHook(hook, opts = {}) {
       throw new TypeError(`Invalid Extension: ${ext}`);
     }
     const oldLoader = Module._extensions[ext] || originalJSLoader;
-    oldLoaders[ext] = oldLoader;
+    oldLoaders[ext] = Module._extensions[ext];
 
     loaders[ext] = Module._extensions[ext] = function newLoader(mod, filename) {
       let compile;

--- a/test/basics.js
+++ b/test/basics.js
@@ -56,3 +56,29 @@ test('matcher is called only once per file', (t) => {
 
   reverts.forEach(call);
 });
+
+test('reverts to previous loader', (t) => {
+  require.extensions['.foojs'] = require.extensions['.js'];
+  const revert = t.context.addHook((code) => code.replace('@@a', '<a>'), {
+    exts: ['.foojs'],
+  });
+
+  t.not(require.extensions['.foojs'], require.extensions['.js']);
+
+  revert();
+
+  t.is(require.extensions['.foojs'], require.extensions['.js']);
+});
+
+test('reverts to nothing if no previous loader', (t) => {
+  t.is(require.extensions['.foo2js'], undefined);
+  const revert = t.context.addHook((code) => code.replace('@@a', '<a>'), {
+    exts: ['.foo2js'],
+  });
+
+  t.not(require.extensions['.foo2js'], undefined);
+
+  revert();
+
+  t.is(require.extensions['.foo2js'], undefined);
+});


### PR DESCRIPTION
Fixes #61